### PR TITLE
made filename handling more flexible (fixes wikia URLs etc)

### DIFF
--- a/Quicksave.plugin.js
+++ b/Quicksave.plugin.js
@@ -399,7 +399,7 @@ class Quicksave {
             name += 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-'[(Math.random() * 64 | 0)];
         return name;
     }
-
+    
     saveCurrentFile(url, filename, overwrite = false) {
         if (url == '') {
             PluginUtilities.showToast(this.local.modals.error.invalidUrl, {type: 'error'});
@@ -413,14 +413,17 @@ class Quicksave {
         
         if (/:large$/.test(url))
             url = url.replace(/:large$/, '');
-        
+
+        // Get the last instance of something that looks like a valid filename
+        let fullFilename = /[^?=\/\\]+\.\w{3,4}(?!.*\.)/.exec(url)[0];
+
         if (!filename && this.settings.norandom)
-            filename = url.split('/').slice(-1)[0].split('?')[0].split('.')[0];
+            filename = fullFilename.substring(0,fullFilename.lastIndexOf('.'));
         
         if ((!filename && !overwrite && !this.settings.addnum) || (this.settings.randomizeUnknown && filename == 'unknown'))
             filename = this.randomFilename64(this.settings.fnLength);
 
-        let filetype = '.' + url.split('.').slice(-1)[0].split('?')[0],
+        let filetype = '.' + fullFilename.split('.').slice(-1)[0],
             tries    = 50;
         
         if (this.settings.addnum)


### PR DESCRIPTION
Current URL-to-filename handling is unable to deal with certain types of URLs.
e.g. wikia's `http://url.com/path/to/somefile.jpg/revision/latest?cb=20180221230614`
...or parameter-based image loaders e.g. `http://url.com/api/loadimage.aspx?image=somefile.jpg&rev=1`

For simplicity's sake, I switched it over to a regex-based format that simply looks for the last thing that looks like a valid filename within the URL. This should get accurate results for the vast majority of URLs, and should possibly only "fail" in some extremely bizarre edge cases.

It might be a good idea to improve this further by hardcoding allowed file extensions into the regex, which ought to take care of any such edge cases, but this would require knowing exactly which image filetypes discord actually supports and may ultimately just not be necessary.

This commit does not fix the potential issue of whether discord is able to display images from web apis that don't actually present a real filename in their URL. I haven't actually seen this happen yet in practice, and I have no idea whether it is even possible, but it might still be something that potentially needs addressing at some point.