### PR TITLE
Fixed incompatibility with BetterImagePopups plugin blob links

### DIFF
--- a/Quicksave.plugin.js
+++ b/Quicksave.plugin.js
@@ -272,7 +272,7 @@ class Quicksave {
                     }).on('keyup.qs', e => button.html(this.local.quicksave));
                     button.click(e => {
                         button.html(self.local.quicksave);
-                        let filePath = $('.modal-1UGdnR .inner-1JeGVc .imageWrapper-2p5ogY img')[0].attributes['src'].nodeValue;
+                        let filePath = $('.modal-1UGdnR .inner-1JeGVc').find('a').filter('[href^="http"]')[0].attributes['href'].nodeValue;
                         if (e.shiftKey)
                             self.openModal($(PluginUtilities.formatString(self.modals.name, {
                                 insertFilename: this.local.modals.filenameChoose.insertFilename,


### PR DESCRIPTION
The BetterImagePopups plugin (which adds some rather fancy tricks to the image lightbox like full-window, zoomable images with visible download progress) recently did an update which involves altering the `img` tag's `src` attribute so that there is a lower-resolution preview visible as the image downloads, before switching it to the higher-resolution version. The URL in this value doesn't reliably point to the file we want to save, and it's in a `blob:` format, meaning Quicksave can't currently use it directly anyway.

Fortunately, the original full-scale image URL is still kept within the `Open original` link under the image, so we can just use that instead.

Since that link is normally by itself, it has no ID value. We also can't use the innerHTML to identify the element either, since it changes with the language setting. Instead, I opted to have it grab the first `a` element below the image with an `href` attribute starting with `http`. There shouldn't be anything else in this area with an external URL as its `href` value, so this should pretty much guarantee we get the right URL, unless some other plugins are doing something _really_ strange. It's also rather unlikely that anything would be messing with this URL, so it should be pretty reliable.