### PR TITLE
shows Save button on search results when hovering over the result

### DIFF
--- a/Quicksave.plugin.js
+++ b/Quicksave.plugin.js
@@ -923,6 +923,7 @@ class Quicksave {
                     opacity: 0;
                 }
 
+                .messageGroupCozy-1BZuO8:hover .thumbQuicksave,
                 .imageWrapper-2p5ogY:hover .thumbQuicksave {
                     opacity: 0.8;
                 }


### PR DESCRIPTION
currently, Save button only appears on images in search results when you hover directly over where the button is located. This fix allows it to be displayed whenever you hover over any part of the result itself, making its presence more obvious. Should close #7.