### PR TITLE
Fixed load function, filename bug, image url grabbing bug, and a file extension bug

### DIFF
--- a/Quicksave.plugin.js
+++ b/Quicksave.plugin.js
@@ -282,8 +282,8 @@ class Quicksave {
 		if (!document.getElementById(`${this.getName()}-inputs`)) BdApi.injectCSS(`${this.getName()}-inputs`, this.css.input)
 
 		let libraryScript=document.getElementById('ZLibraryScript');
-		if (typeof ZLibrary !== "undefined") this.initialize();
-		else libraryScript.addEventListener('load', () => this.initialize());
+		if(typeof window.ZLibrary!=="undefined")this.initialize();
+		else libraryScript.addEventListener('load',()=>this.initialize());
 	}
 	initialize() {
 		ZLibrary.PluginUpdater.checkForUpdate(this.getName(), this.getVersion(), "https://raw.githubusercontent.com/nirewen/Quicksave/master/Quicksave.plugin.js");

--- a/Quicksave.plugin.js
+++ b/Quicksave.plugin.js
@@ -591,8 +591,10 @@ class Quicksave {
             url = url.replace(/:large$/, '');
             
         // Get the last instance of something that looks like a valid filename, the last instance of anything usable at all
-        let fullFilename = /^\w+:\/\/[^\/]+\/(?:.*?\/)*?([^?=\/\\]+\.\w{3,}(?!.*\.)|[\w-\.]+(?=$|\/mp4))/.exec(url)[1];
-        
+		let fullFilename = /^\w+:\/\/[^\/]+\/(?:.*?\/)*?([^?=\/\\]+\.\w{3,}(?!.*\.)|[\w-\.]+(?=$|\/mp4))/.exec(url);
+		// On some occasions fullFilename could throw an error when trying to use the first property
+		if(fullFilename!==null&&fullFilename[1]!==null)fullFilename=fullFilename[1];
+
         // If the URL is so bizarre that nothing matches at all, just give it a random name
         if (!fullFilename)
             fullFilename = this.randomFilename64(this.settings.fnLength);

--- a/Quicksave.plugin.js
+++ b/Quicksave.plugin.js
@@ -590,13 +590,13 @@ class Quicksave {
             url = url.replace(/:large$/, '');
             
         // Get the last instance of something that looks like a valid filename, the last instance of anything usable at all
-		let fullFilename = /^\w+:\/\/[^\/]+\/(?:.*?\/)*?([^?=\/\\]+\.\w{3,}(?!.*\.)|[\w-\.]+(?=$|\/mp4))/.exec(url);
-		// On some occasions fullFilename could throw an error when trying to use the first property
+		let fullFilename=/^\w+:\/\/[^\/]+\/(?:.*?\/)*?([^?=\/\\]+\.\w{3,}(?!.*\.)|[\w-\.]+(?=$|\/mp4))/.exec(url);
+		
+		// On some occasions fullFilename could throw an error when trying to use the [1] property.
 		if(fullFilename!==null&&fullFilename[1]!==null)fullFilename=fullFilename[1];
 
         // If the URL is so bizarre that nothing matches at all, just give it a random name
-        if (!fullFilename)
-            fullFilename = this.randomFilename64(this.settings.fnLength);
+        if (!fullFilename)fullFilename=this.randomFilename64(this.settings.fnLength);
         
         // If it's a virtualized URL with no valid extension, best we can do is make one up and let the OS (attempt to) handle the rest.
         let dotIndex = fullFilename.indexOf('.');

--- a/Quicksave.plugin.js
+++ b/Quicksave.plugin.js
@@ -5,7 +5,7 @@
 class Quicksave {
     get local() {
 		let lang = navigator.language;
-        if (document.documentElement.getAttribute('lang')) lang = document.documentElement.getAttribute('lang').split('-')[0];
+    	if(document.documentElement.getAttribute('lang'))lang=document.documentElement.getAttribute('lang').split('-')[0];
         switch (lang) {
             case "es": // Spanish
                 return {
@@ -275,19 +275,19 @@ class Quicksave {
     getAuthor     () { return "Nirewen"             }
     getName       () { return "Quicksave"           }
     getDescription() { return this.local.description}
-    getVersion    () { return "0.3.1"               }
+    getVersion    () { return "0.3.2"               }
     start         () {
 		if (!document.getElementById(`${this.getName()}`)) BdApi.injectCSS(`${this.getName()}`, this.css.modals);
 		if (!document.getElementById(`${this.getName()}-style`)) BdApi.injectCSS(`${this.getName()}-style`, this.css.thumb);
 		if (!document.getElementById(`${this.getName()}-inputs`)) BdApi.injectCSS(`${this.getName()}-inputs`, this.css.input)
 
 		let libraryScript=document.getElementById('ZLibraryScript');
-		if (typeof window.ZLibrary !== "undefined") this.initialize();
+		if (typeof ZLibrary !== "undefined") this.initialize();
 		else libraryScript.addEventListener('load', () => this.initialize());
 	}
 	initialize() {
-		window.ZLibrary.PluginUpdater.checkForUpdate(this.getName(), this.getVersion(), "https://raw.githubusercontent.com/nirewen/Quicksave/master/Quicksave.plugin.js");
-		if (settingsCookie['fork-ps-2'] === false) window.ZLibrary.Toasts.show(window.ZLibrary.Utilities.formatTString(this.local.startMessage, {pluginName: this.getName(), version: this.getVersion()}));
+		ZLibrary.PluginUpdater.checkForUpdate(this.getName(), this.getVersion(), "https://raw.githubusercontent.com/nirewen/Quicksave/master/Quicksave.plugin.js");
+		if (settingsCookie['fork-ps-2'] === false) ZLibrary.Toasts.show(ZLibrary.Utilities.formatTString(this.local.startMessage, {pluginName: this.getName(), version: this.getVersion()}));
 		this.initialized = true;
 		this.loadSettings();
 		this.injectThumbIcons();
@@ -301,11 +301,10 @@ class Quicksave {
 	}
 	load() {
 		let libraryScript=document.getElementById('ZLibraryScript');
-		if(!window.ZLibrary&&!libraryScript){
+		if(!ZLibrary&&!libraryScript){
 			libraryScript=document.createElement('script');
 			libraryScript.setAttribute('type','text/javascript');
-			/*In part borrowed from Zere, so it redirects the user to download the Lib if it does not load correctly and the user does not have the plugin version of the lib.*/
-			libraryScript.addEventListener("error",function(){if(typeof window.ZLibrary==="undefined"){window.BdApi.alert("Library Missing",`The library plugin needed for ${this.getName()} is missing and could not be loaded.<br /><br /><a href="https://betterdiscord.net/ghdl?url=https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js" target="_blank">Click here to download the library!</a>`);}}.bind(this));
+			libraryScript.addEventListener("error",function(){if(typeof ZLibrary==="undefined"){window.BdApi.alert("Library Missing",`The library plugin needed for ${this.getName()} is missing and could not be loaded.<br /><br /><a href="https://betterdiscord.net/ghdl?url=https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js" target="_blank">Click here to download the library!</a>`);}}.bind(this));
 			libraryScript.setAttribute('src','https://rauenzi.github.io/BDPluginLibrary/release/ZLibrary.js');
 			libraryScript.setAttribute('id','ZLibraryScript');
 			document.head.appendChild(libraryScript);
@@ -357,7 +356,7 @@ class Quicksave {
                 modal.find('button.cancel').click(e => self.closeModal(modal));
                 modal.find('button.overwrite').click(e => self.saveCurrentFile(url, modal.find('.already_exists .file-name').text(), true));
                 modal.find('button.gen-random').click(e => self.saveCurrentFile(url, this.randomFilename64(this.settings.fnLength)));
-                modal.find('button.choose-new').click(e => self.openModal($(window.ZLibrary.Utilities.formatTString(self.modals.name, {
+                modal.find('button.choose-new').click(e => self.openModal($(ZLibrary.Utilities.formatTString(self.modals.name, {
                     insertFilename: this.local.modals.filenameChoose.insertFilename,
                     cancel: this.local.modals.generalButtons.cancel,
                     save: this.local.modals.generalButtons.save
@@ -396,7 +395,7 @@ class Quicksave {
                         if (videoEl) filePath = videoEl.attributes['src'].nodeValue;
                         else filePath = $('.modal-1UGdnR .inner-1JeGVc').find('a').filter('[href^="http"]')[0].attributes['href'].nodeValue;
                         if (e.shiftKey)
-                            self.openModal($(window.ZLibrary.Utilities.formatTString(self.modals.name, {
+                            self.openModal($(ZLibrary.Utilities.formatTString(self.modals.name, {
                                 insertFilename: this.local.modals.filenameChoose.insertFilename,
                                 cancel: this.local.modals.generalButtons.cancel,
                                 save: this.local.modals.generalButtons.save
@@ -414,7 +413,7 @@ class Quicksave {
         }
 
         if (elem.hasClass('contextMenu-HLZMGh')) {
-            let link = window.ZLibrary.ReactTools.getReactProperty(elem[0], "return.memoizedProps.attachment.url") || window.ZLibrary.ReactTools.getReactProperty(elem[0], "return.memoizedProps.src"),
+            let link = ZLibrary.ReactTools.getReactProperty(elem[0], "return.memoizedProps.attachment.url") || ZLibrary.ReactTools.getReactProperty(elem[0], "return.memoizedProps.src"),
                 item = $(`<div class="item-1Yvehc qs-item"><span>${this.local.quicksave}</span><div class="hint-22uc-R"></div></div>`);
             if (link) {
                 $(document)
@@ -429,7 +428,7 @@ class Quicksave {
                         item.find('span').html(self.local.quicksave);
                         $(elem[0]).hide();
                         if (e.shiftKey) {
-                            self.openModal($(window.ZLibrary.Utilities.formatTString(self.modals.name, {
+                            self.openModal($(ZLibrary.Utilities.formatTString(self.modals.name, {
                                 insertFilename: this.local.modals.filenameChoose.insertFilename,
                                 cancel: this.local.modals.generalButtons.cancel,
                                 save: this.local.modals.generalButtons.save
@@ -443,14 +442,14 @@ class Quicksave {
 
         if (elem.find('.downloadButton-23tKQp').length) {
             let anchor = elem.find('.downloadButton-23tKQp').parent(),
-                link   = window.ZLibrary.ReactTools.getReactProperty(anchor[0], 'memoizedProps.href');
+                link   = ZLibrary.ReactTools.getReactProperty(anchor[0], 'memoizedProps.href');
             anchor
                 .on('click.qs', e => {
                     e.preventDefault();
                     e.stopPropagation();
                     tooltip.tooltip.remove();
                     if (e.shiftKey) {
-                        self.openModal($(window.ZLibrary.Utilities.formatTString(self.modals.name, {
+                        self.openModal($(ZLibrary.Utilities.formatTString(self.modals.name, {
                             insertFilename: this.local.modals.filenameChoose.insertFilename,
                             cancel: this.local.modals.generalButtons.cancel,
                             save: this.local.modals.generalButtons.save
@@ -509,11 +508,11 @@ class Quicksave {
 	}
     
     saveSettings() {
-        window.ZLibrary.PluginUtilities.saveSettings(this.getName(), this.settings);
+        ZLibrary.PluginUtilities.saveSettings(this.getName(), this.settings);
     }
 
     loadSettings() {
-        this.settings = window.ZLibrary.PluginUtilities.loadSettings(this.getName(), this.defaultSettings);
+        this.settings = ZLibrary.PluginUtilities.loadSettings(this.getName(), this.defaultSettings);
     }
 
     getSettingsPanel() {
@@ -522,28 +521,28 @@ class Quicksave {
         return panel[0];
     }
     generateSettings(panel) {
-        new window.ZLibrary.Settings.SettingGroup(this.local.settings.panel, {callback: this.loadSettings(), collapsible: true, shown: true}).appendTo(panel).append(
-            new window.ZLibrary.Settings.Textbox(this.local.settings.labels.directory, '', this.settings.directory, text => {
+        new ZLibrary.Settings.SettingGroup(this.local.settings.panel, {callback: this.loadSettings(), collapsible: true, shown: true}).appendTo(panel).append(
+            new ZLibrary.Settings.Textbox(this.local.settings.labels.directory, '', this.settings.directory, text => {
                 if (!text.endsWith('/')) this.settings.directory = `${text}/`; else this.settings.directory = text;
 				this.saveSettings();
             }),
-            new window.ZLibrary.Settings.Switch(this.local.settings.labels.original, this.local.settings.help.original, this.settings.norandom, checked => {
+            new ZLibrary.Settings.Switch(this.local.settings.labels.original, this.local.settings.help.original, this.settings.norandom, checked => {
 				this.settings.norandom = checked;
 				this.saveSettings();
             }),
-            new window.ZLibrary.Settings.Switch(this.local.settings.labels.randomizeUnknown, this.local.settings.help.randomizeUnknown, this.settings.randomizeUnknown, checked => {
+            new ZLibrary.Settings.Switch(this.local.settings.labels.randomizeUnknown, this.local.settings.help.randomizeUnknown, this.settings.randomizeUnknown, checked => {
 				this.settings.randomizeUnknown = checked;
 				this.saveSettings();
             }),
-            new window.ZLibrary.Settings.Switch(this.local.settings.labels.filename, this.local.settings.help.filename, this.settings.showfn, checked => {
+            new ZLibrary.Settings.Switch(this.local.settings.labels.filename, this.local.settings.help.filename, this.settings.showfn, checked => {
 				this.settings.showfn = checked;
 				this.saveSettings();
 			}),
-			new window.ZLibrary.Settings.Textbox(this.local.settings.labels.randomLength, '', this.settings.fnLength, text => {
+			new ZLibrary.Settings.Textbox(this.local.settings.labels.randomLength, '', this.settings.fnLength, text => {
 				if (parseInt(text, 10) !== NaN) this.settings.fnLength = parseInt(text, 10);
 				this.saveSettings();
 			}),
-            new window.ZLibrary.Settings.Switch(this.local.settings.labels.autoAddNum, this.local.settings.help.autoAddNum, this.settings.addnum, checked => {
+            new ZLibrary.Settings.Switch(this.local.settings.labels.autoAddNum, this.local.settings.help.autoAddNum, this.settings.addnum, checked => {
 				this.settings.addnum = checked;
 				this.saveSettings();
 			}));
@@ -557,7 +556,7 @@ class Quicksave {
                     this.settings = this.defaultSettings;
                     this.saveSettings();
                     panel.empty();
-                    this.generateSettings(panel);
+					this.generateSettings(panel);
 				})
         );
     }
@@ -578,7 +577,7 @@ class Quicksave {
     
     saveCurrentFile(url, filename, overwrite = false) {
         if (url == '') {
-            window.ZLibrary.Toasts.show(this.local.modals.error.invalidUrl, {type: 'error'});
+            ZLibrary.Toasts.show(this.local.modals.error.invalidUrl, {type: 'error'});
             return;
         }
 
@@ -622,8 +621,8 @@ class Quicksave {
             filename = this.addNumber(filename, filetype);
 
         if (this.accessSync(dir + filename + filetype) && !overwrite && !this.settings.addnum) {
-            return this.openModal($(window.ZLibrary.Utilities.formatTString(this.modals.error, {
-                alreadyExists: window.ZLibrary.Utilities.formatTString(this.local.modals.error.alreadyExists, {filename, filetype}),
+            return this.openModal($(ZLibrary.Utilities.formatTString(this.modals.error, {
+                alreadyExists: ZLibrary.Utilities.formatTString(this.local.modals.error.alreadyExists, {filename, filetype}),
                 question: this.local.modals.error.question,
                 cancel: this.local.modals.generalButtons.cancel,
                 chooseNew: this.local.modals.error.chooseNew,
@@ -638,7 +637,7 @@ class Quicksave {
             filename = this.randomFilename64(this.settings.fnLength);
 
         if (tries == -1)
-            return window.ZLibrary.Toasts.show(this.local.noFreeName, {type: 'error'});
+            return ZLibrary.Toasts.show(this.local.noFreeName, {type: 'error'});
 
         filename += filetype;
 
@@ -650,15 +649,14 @@ class Quicksave {
             res.pipe(file);
             file.on('finish', () => {
                 button.html(self.local.quicksave);
-                window.ZLibrary.Toasts.show(self.local.finished, {type: 'success'});
-                if (self.settings.showfn)
-				window.ZLibrary.Toasts.show(window.ZLibrary.Utilities.formatTString(self.local.filename, {filename}), {type: 'info'});
+                ZLibrary.Toasts.show(self.local.finished, {type: 'success'});
+                if (self.settings.showfn)ZLibrary.Toasts.show(ZLibrary.Utilities.formatTString(self.local.filename, {filename}), {type: 'info'});
                 file.close();
                 
             });
         }).on('error', err => {
             fs.unlink(dest);
-            window.ZLibrary.Toasts.show(err.message, {type: 'error'});
+            ZLibrary.Toasts.show(err.message, {type: 'error'});
             file.close();
         });
     }

--- a/Quicksave.plugin.js
+++ b/Quicksave.plugin.js
@@ -517,7 +517,7 @@ class Quicksave {
 
     getSettingsPanel() {
         let panel = $("<form>").addClass("form").css("width", "100%");
-        if (this.initialized) this.generateSettings(panel);
+        if (this.initialized)this.generateSettings(panel);
         return panel[0];
     }
     generateSettings(panel) {
@@ -553,9 +553,9 @@ class Quicksave {
             </div>`),
             $(`<button type="button" class="button-38aScr lookOutlined-3sRXeN colorRed-1TFJan sizeMedium-1AC_Sl grow-q77ONN" style='margin: 10px 0; float: right;'><div class="contents-18-Yxp">${this.local.reset}</div></button>`)
                 .click(() => {
-                    this.settings = this.defaultSettings;
-                    this.saveSettings();
-                    panel.empty();
+                    this.settings=this.defaultSettings;
+					this.saveSettings();
+					panel.empty();
 					this.generateSettings(panel);
 				})
         );
@@ -591,7 +591,7 @@ class Quicksave {
             
         // Get the last instance of something that looks like a valid filename, the last instance of anything usable at all
 		let fullFilename=/^\w+:\/\/[^\/]+\/(?:.*?\/)*?([^?=\/\\]+\.\w{3,}(?!.*\.)|[\w-\.]+(?=$|\/mp4))/.exec(url);
-		
+
 		// On some occasions fullFilename could throw an error when trying to use the [1] property.
 		if(fullFilename!==null&&fullFilename[1]!==null)fullFilename=fullFilename[1];
 
@@ -599,7 +599,7 @@ class Quicksave {
         if (!fullFilename)fullFilename=this.randomFilename64(this.settings.fnLength);
         
         // If it's a virtualized URL with no valid extension, best we can do is make one up and let the OS (attempt to) handle the rest.
-        let dotIndex = fullFilename.indexOf('.');
+        let dotIndex = fullFilename.lastIndexOf('.'); // Needs to be lastIndexOf for things like saving plugin files that are uploaded. Otherwise they will get extra file extensions.
         if (dotIndex == -1 || fullFilename.length - dotIndex > 5) { // If we don't have a dot, or we do but it's obviously not an extension
             if (url.endsWith('/mp4'))
                 fullFilename += '.mp4';
@@ -666,8 +666,12 @@ class Quicksave {
 		var button = e.srcElement;
 		var plugin = BdApi.getPlugin('Quicksave');
 
-
 		var url = button.parentElement.href;
+		// Attempt to handle the case where it is trying to download a webpage from the parent element instead of the image. This tries to handle images from, "https://images-ext-2.discordapp.net," as well.
+		if(url.endsWith('.html')&&button.parentElement.getElementsByTagName('img')[0]&&button.parentElement.getElementsByTagName('img')[0].src.startsWith('https://images-ext-2.discordapp.net')){
+			url=button.parentElement.getElementsByTagName('img')[0].src;
+			url=url.substring(url.indexOf('/https'),url.indexOf('?')||url.length).substring(1).replace('https/', 'https://');
+		}
 
 		if(!url) {
 			button.innerHTML = "Error";

--- a/Quicksave.plugin.js
+++ b/Quicksave.plugin.js
@@ -281,13 +281,13 @@ class Quicksave {
 		if (!document.getElementById(`${this.getName()}-style`)) BdApi.injectCSS(`${this.getName()}-style`, this.css.thumb);
 		if (!document.getElementById(`${this.getName()}-inputs`)) BdApi.injectCSS(`${this.getName()}-inputs`, this.css.input)
 
-		let libraryScript = document.getElementById('zeresLibraryScript');
+		let libraryScript=document.getElementById('ZLibraryScript');
 		if (typeof window.ZLibrary !== "undefined") this.initialize();
 		else libraryScript.addEventListener('load', () => this.initialize());
 	}
 	initialize() {
-		ZLibrary.PluginUpdater.checkForUpdate(this.getName(), this.getVersion(), "https://raw.githubusercontent.com/nirewen/Quicksave/master/Quicksave.plugin.js");
-		if (settingsCookie['fork-ps-2'] === false) ZLibrary.Toasts.show(ZLibrary.Utilities.formatTString(this.local.startMessage, {pluginName: this.getName(), version: this.getVersion()}));
+		window.ZLibrary.PluginUpdater.checkForUpdate(this.getName(), this.getVersion(), "https://raw.githubusercontent.com/nirewen/Quicksave/master/Quicksave.plugin.js");
+		if (settingsCookie['fork-ps-2'] === false) window.ZLibrary.Toasts.show(window.ZLibrary.Utilities.formatTString(this.local.startMessage, {pluginName: this.getName(), version: this.getVersion()}));
 		this.initialized = true;
 		this.loadSettings();
 		this.injectThumbIcons();
@@ -300,14 +300,14 @@ class Quicksave {
 		this.initialized = false;
 	}
 	load() {
-		let libraryScript = document.getElementById('zeresLibraryScript'), self = this;
-		if (!libraryScript) {
-			libraryScript = document.createElement('script');
-			libraryScript.setAttribute('type', 'text/javascript');
-			/*In part borrowed from Zere, so it redirects the user to download the Lib if it does not load correctly and the user does not have it.*/
-			libraryScript.onload = function() {if(typeof ZLibrary === "undefined") {window.BdApi.alert("Library Missing",`The library plugin needed for ${self.getName()} is missing and could not be loaded.<br /><br /> <a href="https://betterdiscord.net/ghdl?url=https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js" target="_blank">Click here to download the library!</a>`);}};
-			libraryScript.setAttribute('src', 'https://rauenzi.github.io/BDPluginLibrary/release/ZLibrary.js');
-			libraryScript.setAttribute('id', 'zeresLibraryScript');
+		let libraryScript=document.getElementById('ZLibraryScript');
+		if(!window.ZLibrary&&!libraryScript){
+			libraryScript=document.createElement('script');
+			libraryScript.setAttribute('type','text/javascript');
+			/*In part borrowed from Zere, so it redirects the user to download the Lib if it does not load correctly and the user does not have the plugin version of the lib.*/
+			libraryScript.addEventListener("error",function(){if(typeof window.ZLibrary==="undefined"){window.BdApi.alert("Library Missing",`The library plugin needed for ${this.getName()} is missing and could not be loaded.<br /><br /><a href="https://betterdiscord.net/ghdl?url=https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js" target="_blank">Click here to download the library!</a>`);}}.bind(this));
+			libraryScript.setAttribute('src','https://rauenzi.github.io/BDPluginLibrary/release/ZLibrary.js');
+			libraryScript.setAttribute('id','ZLibraryScript');
 			document.head.appendChild(libraryScript);
 		}
 	}
@@ -357,7 +357,7 @@ class Quicksave {
                 modal.find('button.cancel').click(e => self.closeModal(modal));
                 modal.find('button.overwrite').click(e => self.saveCurrentFile(url, modal.find('.already_exists .file-name').text(), true));
                 modal.find('button.gen-random').click(e => self.saveCurrentFile(url, this.randomFilename64(this.settings.fnLength)));
-                modal.find('button.choose-new').click(e => self.openModal($(ZLibrary.Utilities.formatTString(self.modals.name, {
+                modal.find('button.choose-new').click(e => self.openModal($(window.ZLibrary.Utilities.formatTString(self.modals.name, {
                     insertFilename: this.local.modals.filenameChoose.insertFilename,
                     cancel: this.local.modals.generalButtons.cancel,
                     save: this.local.modals.generalButtons.save
@@ -396,7 +396,7 @@ class Quicksave {
                         if (videoEl) filePath = videoEl.attributes['src'].nodeValue;
                         else filePath = $('.modal-1UGdnR .inner-1JeGVc').find('a').filter('[href^="http"]')[0].attributes['href'].nodeValue;
                         if (e.shiftKey)
-                            self.openModal($(ZLibrary.Utilities.formatTString(self.modals.name, {
+                            self.openModal($(window.ZLibrary.Utilities.formatTString(self.modals.name, {
                                 insertFilename: this.local.modals.filenameChoose.insertFilename,
                                 cancel: this.local.modals.generalButtons.cancel,
                                 save: this.local.modals.generalButtons.save
@@ -414,7 +414,7 @@ class Quicksave {
         }
 
         if (elem.hasClass('contextMenu-HLZMGh')) {
-            let link = ZLibrary.ReactTools.getReactProperty(elem[0], "return.memoizedProps.attachment.url") || ZLibrary.ReactTools.getReactProperty(elem[0], "return.memoizedProps.src"),
+            let link = window.ZLibrary.ReactTools.getReactProperty(elem[0], "return.memoizedProps.attachment.url") || window.ZLibrary.ReactTools.getReactProperty(elem[0], "return.memoizedProps.src"),
                 item = $(`<div class="item-1Yvehc qs-item"><span>${this.local.quicksave}</span><div class="hint-22uc-R"></div></div>`);
             if (link) {
                 $(document)
@@ -429,7 +429,7 @@ class Quicksave {
                         item.find('span').html(self.local.quicksave);
                         $(elem[0]).hide();
                         if (e.shiftKey) {
-                            self.openModal($(ZLibrary.Utilities.formatTString(self.modals.name, {
+                            self.openModal($(window.ZLibrary.Utilities.formatTString(self.modals.name, {
                                 insertFilename: this.local.modals.filenameChoose.insertFilename,
                                 cancel: this.local.modals.generalButtons.cancel,
                                 save: this.local.modals.generalButtons.save
@@ -443,14 +443,14 @@ class Quicksave {
 
         if (elem.find('.downloadButton-23tKQp').length) {
             let anchor = elem.find('.downloadButton-23tKQp').parent(),
-                link   = ZLibrary.ReactTools.getReactProperty(anchor[0], 'memoizedProps.href');
+                link   = window.ZLibrary.ReactTools.getReactProperty(anchor[0], 'memoizedProps.href');
             anchor
                 .on('click.qs', e => {
                     e.preventDefault();
                     e.stopPropagation();
                     tooltip.tooltip.remove();
                     if (e.shiftKey) {
-                        self.openModal($(ZLibrary.Utilities.formatTString(self.modals.name, {
+                        self.openModal($(window.ZLibrary.Utilities.formatTString(self.modals.name, {
                             insertFilename: this.local.modals.filenameChoose.insertFilename,
                             cancel: this.local.modals.generalButtons.cancel,
                             save: this.local.modals.generalButtons.save
@@ -509,11 +509,11 @@ class Quicksave {
 	}
     
     saveSettings() {
-        ZLibrary.PluginUtilities.saveSettings(this.getName(), this.settings);
+        window.ZLibrary.PluginUtilities.saveSettings(this.getName(), this.settings);
     }
 
     loadSettings() {
-        this.settings = ZLibrary.PluginUtilities.loadSettings(this.getName(), this.defaultSettings);
+        this.settings = window.ZLibrary.PluginUtilities.loadSettings(this.getName(), this.defaultSettings);
     }
 
     getSettingsPanel() {
@@ -522,28 +522,28 @@ class Quicksave {
         return panel[0];
     }
     generateSettings(panel) {
-        new ZLibrary.Settings.SettingGroup(this.local.settings.panel, {callback: this.loadSettings(), collapsible: true, shown: true}).appendTo(panel).append(
-            new ZLibrary.Settings.Textbox(this.local.settings.labels.directory, '', this.settings.directory, text => {
+        new window.ZLibrary.Settings.SettingGroup(this.local.settings.panel, {callback: this.loadSettings(), collapsible: true, shown: true}).appendTo(panel).append(
+            new window.ZLibrary.Settings.Textbox(this.local.settings.labels.directory, '', this.settings.directory, text => {
                 if (!text.endsWith('/')) this.settings.directory = `${text}/`; else this.settings.directory = text;
 				this.saveSettings();
             }),
-            new ZLibrary.Settings.Switch(this.local.settings.labels.original, this.local.settings.help.original, this.settings.norandom, checked => {
+            new window.ZLibrary.Settings.Switch(this.local.settings.labels.original, this.local.settings.help.original, this.settings.norandom, checked => {
 				this.settings.norandom = checked;
 				this.saveSettings();
             }),
-            new ZLibrary.Settings.Switch(this.local.settings.labels.randomizeUnknown, this.local.settings.help.randomizeUnknown, this.settings.randomizeUnknown, checked => {
+            new window.ZLibrary.Settings.Switch(this.local.settings.labels.randomizeUnknown, this.local.settings.help.randomizeUnknown, this.settings.randomizeUnknown, checked => {
 				this.settings.randomizeUnknown = checked;
 				this.saveSettings();
             }),
-            new ZLibrary.Settings.Switch(this.local.settings.labels.filename, this.local.settings.help.filename, this.settings.showfn, checked => {
+            new window.ZLibrary.Settings.Switch(this.local.settings.labels.filename, this.local.settings.help.filename, this.settings.showfn, checked => {
 				this.settings.showfn = checked;
 				this.saveSettings();
 			}),
-			new ZLibrary.Settings.Textbox(this.local.settings.labels.randomLength, '', this.settings.fnLength, text => {
+			new window.ZLibrary.Settings.Textbox(this.local.settings.labels.randomLength, '', this.settings.fnLength, text => {
 				if (parseInt(text, 10) !== NaN) this.settings.fnLength = parseInt(text, 10);
 				this.saveSettings();
 			}),
-            new ZLibrary.Settings.Switch(this.local.settings.labels.autoAddNum, this.local.settings.help.autoAddNum, this.settings.addnum, checked => {
+            new window.ZLibrary.Settings.Switch(this.local.settings.labels.autoAddNum, this.local.settings.help.autoAddNum, this.settings.addnum, checked => {
 				this.settings.addnum = checked;
 				this.saveSettings();
 			}));
@@ -558,7 +558,7 @@ class Quicksave {
                     this.saveSettings();
                     panel.empty();
                     this.generateSettings(panel);
-                })
+				})
         );
     }
 
@@ -578,7 +578,7 @@ class Quicksave {
     
     saveCurrentFile(url, filename, overwrite = false) {
         if (url == '') {
-            ZLibrary.Toasts.show(this.local.modals.error.invalidUrl, {type: 'error'});
+            window.ZLibrary.Toasts.show(this.local.modals.error.invalidUrl, {type: 'error'});
             return;
         }
 
@@ -620,8 +620,8 @@ class Quicksave {
             filename = this.addNumber(filename, filetype);
 
         if (this.accessSync(dir + filename + filetype) && !overwrite && !this.settings.addnum) {
-            return this.openModal($(ZLibrary.Utilities.formatTString(this.modals.error, {
-                alreadyExists: ZLibrary.Utilities.formatTString(this.local.modals.error.alreadyExists, {filename, filetype}),
+            return this.openModal($(window.ZLibrary.Utilities.formatTString(this.modals.error, {
+                alreadyExists: window.ZLibrary.Utilities.formatTString(this.local.modals.error.alreadyExists, {filename, filetype}),
                 question: this.local.modals.error.question,
                 cancel: this.local.modals.generalButtons.cancel,
                 chooseNew: this.local.modals.error.chooseNew,
@@ -636,7 +636,7 @@ class Quicksave {
             filename = this.randomFilename64(this.settings.fnLength);
 
         if (tries == -1)
-            return ZLibrary.Toasts.show(this.local.noFreeName, {type: 'error'});
+            return window.ZLibrary.Toasts.show(this.local.noFreeName, {type: 'error'});
 
         filename += filetype;
 
@@ -648,15 +648,15 @@ class Quicksave {
             res.pipe(file);
             file.on('finish', () => {
                 button.html(self.local.quicksave);
-                ZLibrary.Toasts.show(self.local.finished, {type: 'success'});
+                window.ZLibrary.Toasts.show(self.local.finished, {type: 'success'});
                 if (self.settings.showfn)
-                    ZLibrary.Toasts.show(ZLibrary.Utilities.formatTString(self.local.filename, {filename}), {type: 'info'});
+				window.ZLibrary.Toasts.show(window.ZLibrary.Utilities.formatTString(self.local.filename, {filename}), {type: 'info'});
                 file.close();
                 
             });
         }).on('error', err => {
             fs.unlink(dest);
-            ZLibrary.Toasts.show(err.message, {type: 'error'});
+            window.ZLibrary.Toasts.show(err.message, {type: 'error'});
             file.close();
         });
     }


### PR DESCRIPTION
Changed the load function to better match [the documentation](https://rauenzi.github.io/BDPluginLibrary/docs/#using-remote-library) to solve some unintended issues with the remote library.
Fixed a filename bug where it would error out upon not finding _fullFileName[1]_.
Fixed a bug where clicking save on github profile avatars would download the webpage instead of the image.
Fixed a bug where saving a file that is uploaded to discord through the context menu adds an irrelevant extension even though it already has one. This would occur with plugin files, for example: _Quicksave.plugin.js_ would be renamed to _Quicksave.plugin.js.jpg_.